### PR TITLE
fix: vercel readonly file system

### DIFF
--- a/packages/constants/index.ts
+++ b/packages/constants/index.ts
@@ -27,8 +27,11 @@ export const siteConstants = {
   settingStoragePrefix: 'ai-assisatant-storage',
 };
 
+const devStorePath = path.resolve(__dirname, '../../message-store.json');
+const prodStorePath = path.join('/tmp', 'message-store.json');
+
 export const systemConstants = {
-  messageStorePath: path.resolve(__dirname, '../../message-store.json'),
+  messageStorePath: __DEV__ ? devStorePath : prodStorePath,
 };
 
 console.log(systemConstants.messageStorePath);


### PR DESCRIPTION
if try to write data from a serverless function to a read-only file at runtime may cause error

ref https://github.com/vercel/community/discussions/314?sort=new